### PR TITLE
Add monitoring and sylog optionally

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,14 +2,20 @@ freebsd_instance:
   image_family: freebsd-12-1
 
 freebsd_task:
-  env:
-    matrix:
-      - OCAML_VERSION: 4.13.1
-      - OCAML_VERSION: 4.14.0
   pkg_install_script: pkg install -y ocaml-opam gmake bash
-  ocaml_script: opam init -a --comp=$OCAML_VERSION
+  ocaml_script: opam init -a --comp=4.13.1
   mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>4"
   configure_script: eval `opam env` && mirage configure -t hvt
+  depend_script: eval `opam env` && gmake depend
+  build_script: eval `opam env` && mirage build
+  secondary_artifacts:
+    path: dist/secondary.hvt
+
+freebsd_monitoring_task:
+  pkg_install_script: pkg install -y ocaml-opam gmake bash
+  ocaml_script: opam init -a --comp=4.14.1
+  mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>4"
+  configure_script: eval `opam env` && mirage configure -t hvt --monitoring
   depend_script: eval `opam env` && gmake depend
   build_script: eval `opam env` && mirage build
   secondary_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ freebsd_monitoring_task:
   pkg_install_script: pkg install -y ocaml-opam gmake bash
   ocaml_script: opam init -a --comp=4.14.1
   mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>4"
-  configure_script: eval `opam env` && mirage configure -t hvt --monitoring
+  configure_script: eval `opam env` && mirage configure -t hvt --enable-monitoring
   depend_script: eval `opam env` && gmake depend
   build_script: eval `opam env` && mirage build
   secondary_artifacts:

--- a/config.ml
+++ b/config.ml
@@ -6,19 +6,38 @@ let keys =
   let doc = Key.Arg.info ~doc:"nsupdate keys (name:type:value,...)" ["keys"] in
   Key.(create "keys" Arg.(opt (list string) [] doc))
 
+let monitor =
+  let doc = Key.Arg.info ~doc:"monitor host IP" ["monitor"] in
+  Key.(create "monitor" Arg.(opt (some ip_address) None doc))
+
+let syslog =
+  let doc = Key.Arg.info ~doc:"syslog host IP" ["syslog"] in
+  Key.(create "syslog" Arg.(opt (some ip_address) None doc))
+
+let name =
+  let doc = Key.Arg.info ~doc:"Name of the unikernel" ["name"] in
+  Key.(create "name" Arg.(opt string "sn.nqsb.io" doc))
+
 let dns_handler =
   let packages =
     [
       package "logs" ;
       package ~min:"5.0.0" ~sublibs:["mirage"] "dns-server";
       package "dns-tsig";
+      package "mirage-monitoring";
+      package ~sublibs:["mirage"] ~min:"0.3.0" "logs-syslog";
     ]
-  and keys = Key.([ v keys ])
+  and keys = [
+    Key.v keys ;
+    Key.v name ; Key.v monitor ; Key.v syslog
+  ]
   in
   foreign
     ~keys
     ~packages
-    "Unikernel.Main" (random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> job)
+    "Unikernel.Main" (console @-> random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> stackv4v6 @-> job)
+
+let management_stack = generic_stackv4v6 ~group:"management" (netif ~group:"management" "management")
 
 let () =
-  register "secondary" [dns_handler $ default_random $ default_posix_clock $ default_monotonic_clock $ default_time $ generic_stackv4v6 default_network ]
+  register "secondary" [dns_handler $ default_console $ default_random $ default_posix_clock $ default_monotonic_clock $ default_time $ generic_stackv4v6 default_network $ management_stack ]

--- a/config.ml
+++ b/config.ml
@@ -23,9 +23,9 @@ let dns_handler =
 let enable_monitoring =
   let doc = Key.Arg.info
       ~doc:"Enable monitoring (only available for solo5 targets)"
-      [ "monitoring" ]
+      [ "enable-monitoring" ]
   in
-  Key.(create "metrics" Arg.(flag ~stage:`Configure doc))
+  Key.(create "enable-monitoring" Arg.(flag ~stage:`Configure doc))
 
 let stack = generic_stackv4v6 default_network
 

--- a/config.ml
+++ b/config.ml
@@ -6,38 +6,93 @@ let keys =
   let doc = Key.Arg.info ~doc:"nsupdate keys (name:type:value,...)" ["keys"] in
   Key.(create "keys" Arg.(opt (list string) [] doc))
 
-let monitor =
-  let doc = Key.Arg.info ~doc:"monitor host IP" ["monitor"] in
-  Key.(create "monitor" Arg.(opt (some ip_address) None doc))
-
-let syslog =
-  let doc = Key.Arg.info ~doc:"syslog host IP" ["syslog"] in
-  Key.(create "syslog" Arg.(opt (some ip_address) None doc))
-
-let name =
-  let doc = Key.Arg.info ~doc:"Name of the unikernel" ["name"] in
-  Key.(create "name" Arg.(opt string "sn.nqsb.io" doc))
-
 let dns_handler =
   let packages =
     [
       package "logs" ;
       package ~min:"5.0.0" ~sublibs:["mirage"] "dns-server";
       package "dns-tsig";
-      package "mirage-monitoring";
-      package ~sublibs:["mirage"] ~min:"0.3.0" "logs-syslog";
     ]
-  and keys = [
-    Key.v keys ;
-    Key.v name ; Key.v monitor ; Key.v syslog
-  ]
+  and keys = [ Key.v keys ]
   in
   foreign
     ~keys
     ~packages
-    "Unikernel.Main" (console @-> random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> stackv4v6 @-> job)
+    "Unikernel.Main" (random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> job)
 
-let management_stack = generic_stackv4v6 ~group:"management" (netif ~group:"management" "management")
+let enable_monitoring =
+  let doc = Key.Arg.info
+      ~doc:"Enable monitoring (only available for solo5 targets)"
+      [ "monitoring" ]
+  in
+  Key.(create "metrics" Arg.(flag ~stage:`Configure doc))
+
+let stack = generic_stackv4v6 default_network
+
+let management_stack =
+  if_impl
+    (Key.value enable_monitoring)
+    (generic_stackv4v6 ~group:"management" (netif ~group:"management" "management"))
+    stack
+
+let name =
+  let doc = Key.Arg.info ~doc:"Name of the unikernel" [ "name" ] in
+  Key.(v (create "name" Arg.(opt string "a.ns.robur.coop" doc)))
+
+let monitoring =
+  let monitor =
+    let doc = Key.Arg.info ~doc:"monitor host IP" ["monitor"] in
+    Key.(v (create "monitor" Arg.(opt (some ip_address) None doc)))
+  in
+  let connect _ modname = function
+    | [ _ ; _ ; stack ] ->
+      Fmt.str "Lwt.return (match %a with\
+               | None -> Logs.warn (fun m -> m \"no monitor specified, not outputting statistics\")\
+               | Some ip -> %s.create ip ~hostname:%a %s)"
+        Key.serialize_call monitor modname
+        Key.serialize_call name stack
+    | _ -> assert false
+  in
+  impl
+    ~packages:[ package "mirage-monitoring" ]
+    ~keys:[ name ; monitor ]
+    ~connect "Mirage_monitoring.Make"
+    (time @-> pclock @-> stackv4v6 @-> job)
+
+let syslog =
+  let syslog =
+    let doc = Key.Arg.info ~doc:"syslog host IP" ["syslog"] in
+    Key.(v (create "syslog" Arg.(opt (some ip_address) None doc)))
+  in
+  let connect _ modname = function
+    | [ console ; _ ; stack ] ->
+      Fmt.str "Lwt.return (match %a with\
+               | None -> Logs.warn (fun m -> m \"no syslog specified, dumping on stdout\")\
+               | Some ip -> Logs.set_reporter (%s.create %s %s ip ~hostname:%a ()))"
+        Key.serialize_call syslog modname console stack
+        Key.serialize_call name
+    | _ -> assert false
+  in
+  impl
+    ~packages:[ package ~sublibs:["mirage"] ~min:"0.3.0" "logs-syslog" ]
+    ~keys:[ name ; syslog ]
+    ~connect "Logs_syslog_mirage.Udp"
+    (console @-> pclock @-> stackv4v6 @-> job)
+
+let optional_monitoring time pclock stack =
+  if_impl (Key.value enable_monitoring)
+    (monitoring $ time $ pclock $ stack)
+    noop
+
+let optional_syslog console pclock stack =
+  if_impl (Key.value enable_monitoring)
+    (syslog $ console $ pclock $ stack)
+    noop
 
 let () =
-  register "secondary" [dns_handler $ default_console $ default_random $ default_posix_clock $ default_monotonic_clock $ default_time $ generic_stackv4v6 default_network $ management_stack ]
+  register "secondary"
+    [
+      optional_syslog default_console default_posix_clock management_stack ;
+      optional_monitoring default_time default_posix_clock management_stack ;
+      dns_handler $ default_random $ default_posix_clock $ default_monotonic_clock $ default_time $ stack
+    ]

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1,8 +1,18 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
-module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Tcpip.Stack.V4V6) = struct
+module Main (C : Mirage_console.S) (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Tcpip.Stack.V4V6) (Management : Tcpip.Stack.V4V6) = struct
   module D = Dns_server_mirage.Make(P)(M)(T)(S)
 
-  let start _rng _pclock _mclock _ s =
+  module Monitoring = Mirage_monitoring.Make(T)(P)(Management)
+  module Syslog = Logs_syslog_mirage.Udp(C)(P)(Management)
+
+  let start c _rng _pclock _mclock _ s management =
+    let hostname = Key_gen.name () in
+    (match Key_gen.syslog () with
+     | None -> Logs.warn (fun m -> m "no syslog specified, dumping on stdout")
+     | Some ip -> Logs.set_reporter (Syslog.create c management ip ~hostname ()));
+    (match Key_gen.monitor () with
+     | None -> Logs.warn (fun m -> m "no monitor specified, not outputting statistics")
+     | Some ip -> Monitoring.create ~hostname ip management);
     let keys = List.fold_left (fun acc str ->
         match Dns.Dnskey.name_key_of_string str with
         | Error (`Msg msg) -> Logs.err (fun m -> m "key parse error %s" msg) ; exit 64

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1,18 +1,8 @@
 (* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
-module Main (C : Mirage_console.S) (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Tcpip.Stack.V4V6) (Management : Tcpip.Stack.V4V6) = struct
+module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Tcpip.Stack.V4V6) = struct
   module D = Dns_server_mirage.Make(P)(M)(T)(S)
 
-  module Monitoring = Mirage_monitoring.Make(T)(P)(Management)
-  module Syslog = Logs_syslog_mirage.Udp(C)(P)(Management)
-
-  let start c _rng _pclock _mclock _ s management =
-    let hostname = Key_gen.name () in
-    (match Key_gen.syslog () with
-     | None -> Logs.warn (fun m -> m "no syslog specified, dumping on stdout")
-     | Some ip -> Logs.set_reporter (Syslog.create c management ip ~hostname ()));
-    (match Key_gen.monitor () with
-     | None -> Logs.warn (fun m -> m "no monitor specified, not outputting statistics")
-     | Some ip -> Monitoring.create ~hostname ip management);
+  let start _rng _pclock _mclock _ s =
     let keys = List.fold_left (fun acc str ->
         match Dns.Dnskey.name_key_of_string str with
         | Error (`Msg msg) -> Logs.err (fun m -> m "key parse error %s" msg) ; exit 64


### PR DESCRIPTION
Previously, there was the `future` branch in this repository which added the monitoring elements.

An update of the source code included: update the main branch, rebase the future branch on the new main branch, force-push the future branch.

This also meant that some revs aren't available anymore (due to the force-push), and a rather intricate change.

This PR modifies the config.ml to have a configure-time `--monitoring` flag, which, if provided, adds logs-syslog and mirage-monitoring dependency and initialization code. The CI has been modified to run once without --monitoring and once with --monitoring.

WDYT @reynir @dinosaure? If this is fine, I'm keen to adapt other unikernels in the same way.